### PR TITLE
fix resolution crash

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -15,7 +15,18 @@ static TTF_Font* sFont = NULL;
 
 void Renderer::init()
 {
-	sScreen = SDL_SetVideoMode(800, 600, 16, SDL_SWSURFACE | SDL_ANYFORMAT);
+    char* error;
+    const SDL_VideoInfo* myPointer = SDL_GetVideoInfo();
+
+    if (myPointer == NULL ) {
+        std::cout << "SDL_GetVideoInfo() returned NULL in Render::init()";
+    }
+
+       sScreen = SDL_SetVideoMode(myPointer->current_w, myPointer->current_h, 16, SDL_SWSURFACE | SDL_ANYFORMAT);
+    if (sScreen == NULL ) {
+        std::cout << "SDL_SetVideoMode() returned " << SDL_GetError() ; 
+    }
+
 	sScreenWidth = sScreen->w;
 	sScreenHeight = sScreen->h;
 


### PR DESCRIPTION
Attempt to fix a crash if screen resolution is lower than 800x600 (can happen on the rPi if `hdmi_safe=1` in `/boot/config.txt`).

Might fix (https://github.com/Aloshi/ES-config/issues/17)[https://github.com/Aloshi/ES-config/issues/17]
